### PR TITLE
Adds create-management-network action

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -78,6 +78,10 @@ juju config neutron-openvswitch bridge-mappings="physnet2:br-trove" data-port="b
 juju run-action trove/leader create-management-network physical-network=physnet2 \
   cidr=10.8.102.0/24 destination-cidr=10.8.11.0/24 nexthop=10.8.102.1
 
+# The action above can be used to create VLAN networks as well. For more information
+# about the action and its parameters, run:
+juju show-action trove create-management-network
+
 # The created resources can be retrieved by running:
 openstack network list --tag charm-trove
 

--- a/src/README.md
+++ b/src/README.md
@@ -73,7 +73,15 @@ juju config neutron-api flat-network-providers="physnet1 physnet2"
 juju config neutron-gateway bridge-mappings="physnet1:br-ex physnet2:br-trove" data-port="br-ex:eth2 br-trove:eth3"
 juju config neutron-openvswitch bridge-mappings="physnet2:br-trove" data-port="br-trove:eth2"
 
-# Define the flat OpenStack network and subnet.
+# After the charm has been deployed, define the flat OpenStack network, and subnet
+# with a route to the Management Network.
+juju run-action trove/leader create-management-network physical-network=physnet2 \
+  cidr=10.8.102.0/24 destination-cidr=10.8.11.0/24 nexthop=10.8.102.1
+
+# The created resources can be retrieved by running:
+openstack network list --tag charm-trove
+
+# Alternatively, these resources can be created manually:
 openstack network create --share --provider-network-type=flat \
   --provider-physical-network=physnet2 --description "Trove management network" trove-net
 

--- a/src/actions.yaml
+++ b/src/actions.yaml
@@ -25,13 +25,29 @@ create-management-network:
     physical-network:
       type: string
       description: |
-        The physical network name for the flat Neutron network creation.
+        The physical network name for the Neutron network creation.
         This network name must be configured in the `neutron-api` charm's
         `flat-network-providers` config option.
         Through this network, the Trove instances should be able to connect to
         the RabbitMQ charm used by the OpenStack services.
         The network can be retrieved by running:
           openstack network list --tag charm-trove
+    network-type:
+      type: string
+      default: "flat"
+      description: |
+        The network type for the Neutron network creation. Only `flat` and `vlan`
+        network types are supported.
+        If the `network-type` is `vlan`, the `segmentation-id` argument must be given.
+    segmentation-id:
+      type: integer
+      default: 0
+      description: |
+        The Segmentation ID for the Neutron network to be created, if the `network-type`
+        is `vlan`. Not required for `flat` networks.
+        The given `segmentation-id` must be a valid ID within the VLAN range defined for
+        the given `physical-network`, which is set in the `neutron-api` charm's
+        `vlan-ranges` config option.
     cidr:
       type: string
       description: |

--- a/src/actions.yaml
+++ b/src/actions.yaml
@@ -18,3 +18,41 @@ db-load-datastore-config-params:
         The version number of the datastore version, e.g. 5.7.30. If not
         specified, datastore-version-name will be used as default value.
   required: [datastore, datastore-version-name, config-file]
+create-management-network:
+  description: |
+    Creates the Neutron management network for Trove.
+  params:
+    physical-network:
+      type: string
+      description: |
+        The physical network name for the flat Neutron network creation.
+        This network name must be configured in the `neutron-api` charm's
+        `flat-network-providers` config option.
+        Through this network, the Trove instances should be able to connect to
+        the RabbitMQ charm used by the OpenStack services.
+        The network can be retrieved by running:
+          openstack network list --tag charm-trove
+    cidr:
+      type: string
+      description: |
+        The subnet to be used by the Trove instances on the management network.
+    destination-cidr:
+      type: string
+      default: ""
+      description: |
+        The RabbitMQ charm subnet.
+        This, together with `nexthop`, are required if the Trove management
+        network subnet is different from the RabbitMQ charm subnet. These
+        arguments will be used to add a route in the Trove instances in order
+        to reach RabbitMQ.
+        The gateway must be able to route traffic between the 2 different
+        CIDRs.
+        Running the action again with different ``destination-cidr`` and
+        ``nexthop`` will result in the new route replacing the older one.
+    nexthop:
+      type: string
+      default: ""
+      description: |
+        The gateway address used to reach `destination-cidr`. Required if
+        `destination-cidr` is given.
+  required: [physical-network, cidr]

--- a/src/actions/actions.py
+++ b/src/actions/actions.py
@@ -28,6 +28,84 @@ from charms import reactive
 from charmhelpers.core import hookenv
 import requests
 
+from charm.openstack import exceptions
+from charm.openstack import utils
+
+REQUIRED_FLAGS = ['identity-service.available']
+
+
+def create_mgmt_network_action(*args):
+    """Creates Neutron Management Network for Trove instances."""
+    if not reactive.is_flag_set('leadership.is_leader'):
+        return hookenv.action_fail('action must be run on the leader unit.')
+
+    if not reactive.all_flags_set(*REQUIRED_FLAGS):
+        return hookenv.action_fail(
+            'all required relations are not available yet, rerun action when '
+            'deployment is complete.')
+
+    action_args = hookenv.action_get()
+    failure = _validate_create_mgmt_net_action_args(action_args)
+    if failure:
+        return failure
+
+    keystone = reactive.endpoint_from_flag('identity-service.available')
+    try:
+        utils.create_trove_mgmt_network(
+            keystone,
+            action_args['physical-network'],
+            action_args['cidr'],
+            action_args.get('destination-cidr'),
+            action_args.get('nexthop'),
+        )
+    except exceptions.DuplicateResource as ex:
+        msg = (
+            f"The '{ex.resource_type}' to be created by this action was "
+            "already duplicated. This will have to be cleaned up manually."
+        )
+        hookenv.log(f'{msg} Exception: {ex}')
+        return hookenv.action_fail(
+            f'{msg} Check the unit logs for more details.')
+    except exceptions.InvalidResource as ex:
+        msg = (
+            f"The '{ex.resource_type}' to be created by this action already "
+            "exists with different parameters than given to the action. This "
+            "will have to be cleaned up manually."
+        )
+        hookenv.log(f'{msg} Exception: {ex}')
+        return hookenv.action_fail(
+            f'{msg} Check the unit logs for more details.')
+    except exceptions.APIException as ex:
+        hookenv.log(
+            "Encountered exception while creating the Trove management "
+            f"network. Exception: {ex}")
+        return hookenv.action_fail(
+            'Neutron API may not be available yet, rerun action when it is. '
+            'Check the unit logs for more details.')
+
+
+def _validate_create_mgmt_net_action_args(action_args):
+    if not utils.is_cidr(action_args['cidr']):
+        return hookenv.action_fail(
+            "'cidr' argument is invalid. Must be a proper CIDR.")
+
+    dest_cidr = action_args.get('destination-cidr')
+    nexthop = action_args.get('nexthop')
+    # destination-cidr and nexthop are optional, but if they're given, both of
+    # them need to be given.
+    if any([dest_cidr, nexthop]) and not all([dest_cidr, nexthop]):
+        return hookenv.action_fail(
+            "Either both 'destination-cidr' and 'nexthop' arguments must be "
+            "given, or neither.")
+
+    if dest_cidr and not utils.is_cidr(dest_cidr):
+        return hookenv.action_fail(
+            "'destination-cidr' argument is invalid. Must be a proper CIDR.")
+
+    if nexthop and not utils.is_ip(nexthop):
+        return hookenv.action_fail(
+            "'nexthop' argument is invalid. Must be an IP.")
+
 
 def load_datastore_cfg_params_action(*args):
     """Runs trove-manage db_load_datastore_config_parameters on controller."""
@@ -65,10 +143,14 @@ def load_datastore_cfg_params_action(*args):
 # can map to a python function.
 ACTIONS = {
     "db-load-datastore-config-params": load_datastore_cfg_params_action,
+    "create-management-network": create_mgmt_network_action,
 }
 
 
 def main(args):
+    # Manually trigger any register atstart events to ensure all endpoints
+    # are correctly setup, Bug #1916008.
+    hookenv._run_atstart()
     action_name = os.path.basename(args[0])
     try:
         action = ACTIONS[action_name]

--- a/src/actions/create-management-network
+++ b/src/actions/create-management-network
@@ -1,0 +1,1 @@
+actions.py

--- a/src/lib/charm/openstack/exceptions.py
+++ b/src/lib/charm/openstack/exceptions.py
@@ -1,0 +1,71 @@
+# Copyright 2023 Cloudbase Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from keystoneauth1 import exceptions as ks_exc
+from neutronclient.common import exceptions as neutron_exc
+
+
+NEUTRON_EXCS = (
+    ks_exc.catalog.EndpointNotFound,
+    ks_exc.connection.ConnectFailure,
+    ks_exc.discovery.DiscoveryFailure,
+    ks_exc.http.ServiceUnavailable,
+    ks_exc.http.InternalServerError,
+    neutron_exc.ServiceUnavailable,
+    neutron_exc.BadRequest,
+    neutron_exc.NeutronClientException,
+)
+
+
+class TroveCharmException(Exception):
+
+    msg_fmt = 'An exception occured.'
+
+    def __init__(self, msg=None, **kwargs):
+        self.kwargs = kwargs
+
+        if not msg:
+            msg = self.msg_fmt % kwargs
+        else:
+            msg = str(msg)
+
+        self.msg = msg
+        super().__init__(msg)
+
+
+class DuplicateResource(TroveCharmException):
+    msg_fmt = "A duplicate '%(resource_type)s' has been found: %(data)s"
+
+    def __init__(self, msg=None, resource_type=None, data=None):
+        super().__init__(msg, resource_type=resource_type, data=data)
+        self.resource_type = resource_type
+
+
+class InvalidResource(TroveCharmException):
+    msg_fmt = ("Invalid %(resource_type)s with id %(id)s found. "
+               "Details: %(details)s")
+
+    def __init__(self, msg=None, resource_type=None, id=None, details=None):
+        super().__init__(msg, resource_type=resource_type, id=id,
+                         details=details)
+        self.resource_type = resource_type
+
+
+class APIException(TroveCharmException):
+    msg_fmt = ("An error occured while accessing the %(service)s "
+               "%(resource_type)s API. Exception: %(exc)s")
+
+    def __init__(self, msg=None, service=None, resource_type=None, exc=None):
+        super().__init__(msg, service=service, resource_type=resource_type,
+                         exc=exc)

--- a/src/lib/charm/openstack/utils.py
+++ b/src/lib/charm/openstack/utils.py
@@ -1,0 +1,218 @@
+# Copyright 2023 Cloudbase Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import ipaddress
+
+from charmhelpers.core import hookenv
+from keystoneauth1 import identity as ks_identity
+from keystoneauth1 import session as ks_session
+from neutronclient.v2_0 import client as neutron_client
+
+from charm.openstack import exceptions
+
+
+SYSTEM_CA_BUNDLE = '/etc/ssl/certs/ca-certificates.crt'
+TROVE_MGMT_NET = 'trove-net'
+TROVE_MGMT_SUBNET = 'trove-subnet'
+TROVE_TAG = 'charm-trove'
+
+
+def is_cidr(cidr):
+    if '/' not in cidr:
+        return False
+
+    try:
+        # This raises a ValueError if it's not an IP / proper length.
+        ipaddress.ip_network(cidr, False)
+    except ValueError:
+        return False
+
+    return True
+
+
+def is_ip(ip):
+    try:
+        # This raises a ValueError if it's not an IP.
+        ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+
+    return True
+
+
+def api_exc_wrapper(exc_list, service, resource_type):
+    def decorator(func):
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except exc_list as exc:
+                raise exceptions.APIException(
+                    service=service, resource_type=resource_type, exc=exc)
+        return inner
+    return decorator
+
+
+def endpoint_type():
+    if hookenv.config('use-internal-endpoints'):
+        return 'internalURL'
+    return 'publicURL'
+
+
+def get_session_from_keystone(keystone):
+    protocol = keystone.auth_protocol()
+    host = keystone.auth_host()
+    port = keystone.auth_port()
+    auth_url = f"{protocol}://{host}:{port}/"
+    auth = ks_identity.Password(
+        auth_url=auth_url,
+        username=keystone.service_username(),
+        password=keystone.service_password(),
+        project_name=keystone.service_tenant(),
+        user_domain_name=keystone.service_domain(),
+        project_domain_name=keystone.service_domain(),
+    )
+    return ks_session.Session(auth=auth, verify=SYSTEM_CA_BUNDLE)
+
+
+def get_neutron_client(session):
+    return neutron_client.Client(
+        session=session, region_name=hookenv.config('region'),
+        endpoint_type=endpoint_type(),
+    )
+
+
+def create_trove_mgmt_network(keystone, physical_network, cidr,
+                              destination_cidr=None, nexthop=None):
+    session = get_session_from_keystone(keystone)
+    client = get_neutron_client(session)
+
+    network = _get_or_create_network(client, physical_network)
+    _get_or_create_subnet(
+        client, network['id'], cidr, destination_cidr, nexthop)
+
+    return network['id']
+
+
+@api_exc_wrapper(exceptions.NEUTRON_EXCS, 'neutron', 'network')
+def _get_or_create_network(client, physical_network):
+    resp = client.list_networks(tags=TROVE_TAG)
+    networks = resp.get('networks', [])
+    if len(networks) > 1:
+        raise exceptions.DuplicateResource('network', networks)
+
+    # Create the network only if it doesn't exist.
+    if not networks:
+        return _create_network(client, physical_network)
+
+    network = networks[0]
+    set_physnet = network.get('provider:physical_network')
+    if set_physnet != physical_network:
+        # We can't update this field if Neutron doesn't have the
+        # Multiple provider extension.
+        # https://docs.openstack.org/api-ref/network/v2/index.html#multiple-provider-extension
+        details = (
+            'Network already exists with the "provider:physical_network" set '
+            f'to {set_physnet} instead of {physical_network}.'
+        )
+        raise exceptions.InvalidResource('network', network['id'], details)
+    return network
+
+
+def _create_network(client, physical_network):
+    hookenv.log(
+        f"Creating Neutron network for '{physical_network}' physical network.")
+    network_params = {
+        'name': TROVE_MGMT_NET,
+        'provider:network_type': 'flat',
+        'provider:physical_network': physical_network,
+        'shared': True,  # should be shared across projects / tenants.
+        'description': 'Trove management network',
+    }
+    resp = client.create_network({'network': network_params})
+    network = resp['network']
+
+    # We cannot add tags during creation.
+    client.add_tag('networks', network['id'], TROVE_TAG)
+
+    return network
+
+
+@api_exc_wrapper(exceptions.NEUTRON_EXCS, 'neutron', 'subnet')
+def _get_or_create_subnet(client, network_id, cidr, dest_cidr, nexthop):
+    resp = client.list_subnets(network_id=network_id)
+    subnets = resp.get('subnets', [])
+
+    # Create the subnet only if it doesn't exist.
+    if not subnets:
+        return _create_subnet(client, network_id, cidr, dest_cidr, nexthop)
+
+    subnet = subnets[0]
+    if ipaddress.ip_network(cidr) != ipaddress.ip_network(subnet['cidr']):
+        details = (
+            'Subnet already exists with a different CIDR: '
+            f'{subnet["cidr"]} instead of {cidr}.'
+        )
+        raise exceptions.InvalidResource('subnet', subnet['id'], details)
+
+    _update_route(client, subnet, dest_cidr, nexthop)
+
+    return subnet
+
+
+def _create_subnet(client, network_id, cidr, dest_cidr, nexthop):
+    # We're adding a subnet for the Trove management network. The Trove
+    # instance are meant to connect to RabbitMQ, they shouldn't need a gateway
+    # on this  network.
+    hookenv.log(f"Creating '{cidr}' subnet for '{network_id}' network.")
+    subnet_params = {
+        'name': f"{TROVE_MGMT_SUBNET}-v4",
+        'network_id': network_id,
+        'ip_version': 4,
+        'cidr': cidr,
+        'gateway_ip': None,
+        'description': 'Trove management subnet',
+    }
+
+    if dest_cidr and nexthop:
+        hookenv.log(f"Adding route {dest_cidr} via {nexthop} for "
+                    f"{network_id}'s subnet.")
+        subnet_params['host_routes'] = [
+            {'destination': dest_cidr, 'nexthop': nexthop},
+        ]
+
+    resp = client.create_subnet({'subnets': [subnet_params]})
+    return resp['subnets'][0]
+
+
+def _update_route(client, subnet, destination, nexthop):
+    # Check if the route already exists first.
+    for route in subnet['host_routes']:
+        if route['destination'] == destination and route['nexthop'] == nexthop:
+            # Both destination and nexthop matched. Route already exists.
+            # Nothing to do in this case.
+            hookenv.log(
+                f"Subnet {subnet['id']} already has the route: {destination} "
+                f"via {nexthop}.")
+            return
+
+    hookenv.log(
+        f"Adding route to subnet '{subnet['id']}': {destination} via "
+        f"{nexthop}.")
+    params = {
+        'host_routes': [{'destination': destination, 'nexthop': nexthop}],
+    }
+    # This will also override existing routes.
+    client.update_subnet(subnet['id'], {'subnet': params})

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -2,5 +2,8 @@ flit_scm
 anyio<3.7.0
 Cython<3.0
 
+keystoneauth1
+python-neutronclient
+
 git+https://github.com/openstack/charms.openstack.git#egg=charms.openstack
 git+https://github.com/juju/charm-helpers.git#egg=charmhelpers

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,3 +9,5 @@ coverage>=3.6
 git+https://github.com/openstack/charms.openstack#egg=charms.openstack
 
 oslotest>=3.8.0
+keystoneauth1>=3.16.0
+python-neutronclient>=3.1.0,<4.0

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -32,4 +32,6 @@ import charms_openstack.test_mocks  # noqa
 charms_openstack.test_mocks.mock_charmhelpers()
 
 apt_pkg = mock.MagicMock()
+charms = mock.MagicMock()
 sys.modules['apt_pkg'] = apt_pkg
+sys.modules['charms.layer'] = charms.layer

--- a/unit_tests/base.py
+++ b/unit_tests/base.py
@@ -1,0 +1,25 @@
+# Copyright 2023 Cloudbase Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+
+class TestBase(unittest.TestCase):
+    def _patch(self, thing, member):
+        patcher = mock.patch.object(thing, member)
+        mocked = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        return mocked

--- a/unit_tests/test_actions.py
+++ b/unit_tests/test_actions.py
@@ -1,0 +1,121 @@
+# Copyright 2023 Cloudbase Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+from actions import actions
+from charm.openstack import exceptions
+from unit_tests import base
+
+
+class TestCreateMgmtNetworkAction(base.TestBase):
+
+    def setUp(self):
+        super().setUp()
+
+        self._hookenv = self._patch(actions, 'hookenv')
+        self._reactive = self._patch(actions, 'reactive')
+        self._args = {
+            'physical-network': mock.sentinel.physnet,
+            'cidr': '10.10.10.0/24',
+            'destination-cidr': '10.10.9.0/24',
+            'nexthop': '10.10.10.1',
+        }
+        self._hookenv.action_get.return_value = self._args
+
+    def test_create_mgmt_net_not_leader(self):
+        self._reactive.is_flag_set.return_value = False
+
+        result = actions.create_mgmt_network_action()
+
+        self.assertEqual(self._hookenv.action_fail.return_value, result)
+        self._reactive.is_flag_set.assert_called_once_with(
+            'leadership.is_leader')
+        self._reactive.all_flags_set.assert_not_called()
+
+    def test_create_mgmt_net_not_all_flags(self):
+        self._reactive.all_flags_set.return_value = False
+
+        result = actions.create_mgmt_network_action()
+
+        self.assertEqual(self._hookenv.action_fail.return_value, result)
+        self._reactive.all_flags_set.assert_called_once_with(
+            *actions.REQUIRED_FLAGS)
+        self._hookenv.actions_get.assert_not_called()
+
+    def test_create_mgmt_net_fail_validation(self):
+        # Either both destination-cidr and nexthop must exist, or neither.
+        self._args.pop('destination-cidr')
+
+        result = actions.create_mgmt_network_action()
+
+        self.assertEqual(self._hookenv.action_fail.return_value, result)
+        self._reactive.all_flags_set.assert_called_once_with(
+            *actions.REQUIRED_FLAGS)
+
+    @mock.patch.object(actions.utils, 'create_trove_mgmt_network')
+    def test_create_mgmt_net_no_extra_args(self, mock_create_net):
+        self._args.pop('destination-cidr')
+        self._args.pop('nexthop')
+
+        result = actions.create_mgmt_network_action()
+
+        self.assertIsNone(result)
+        self._reactive.endpoint_from_flag.assert_called_once_with(
+            'identity-service.available')
+        mock_create_net.assert_called_once_with(
+            self._reactive.endpoint_from_flag.return_value,
+            mock.sentinel.physnet,
+            self._args['cidr'],
+            None,
+            None,
+        )
+
+    @mock.patch.object(actions.utils, 'create_trove_mgmt_network')
+    def test_create_mgmt_net_exc(self, mock_create_net):
+        for exc in [exceptions.DuplicateResource, exceptions.InvalidResource,
+                    exceptions.APIException]:
+            mock_create_net.side_effect = exc
+
+            result = actions.create_mgmt_network_action()
+
+            self.assertEqual(self._hookenv.action_fail.return_value, result)
+            mock_create_net.assert_called_with(
+                self._reactive.endpoint_from_flag.return_value,
+                mock.sentinel.physnet,
+                self._args['cidr'],
+                self._args['destination-cidr'],
+                self._args['nexthop'],
+            )
+
+    def test_validate_create_mgmt_net_action_args_missing(self):
+        for key in ['destination-cidr', 'nexthop']:
+            value = self._args.pop(key)
+
+            result = actions._validate_create_mgmt_net_action_args(self._args)
+            self.assertEqual(self._hookenv.action_fail.return_value, result,
+                             f"Failed for key '{key}'.")
+
+            self._args[key] = value
+
+    def test_validate_create_mgmt_net_action_args_invalid(self):
+        for key in ['cidr', 'destination-cidr', 'nexthop']:
+            value = self._args.pop(key)
+            self._args[key] = 'foo'
+
+            result = actions._validate_create_mgmt_net_action_args(self._args)
+            self.assertEqual(self._hookenv.action_fail.return_value, result,
+                             f"Failed for key '{key}'.")
+
+            self._args[key] = value

--- a/unit_tests/test_lib_charm_openstack_utils.py
+++ b/unit_tests/test_lib_charm_openstack_utils.py
@@ -1,0 +1,291 @@
+# Copyright 2023 Cloudbase Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from charmhelpers.core import hookenv
+from keystoneauth1 import exceptions as ks_exc
+
+from charm.openstack import exceptions
+from charm.openstack import utils
+
+
+class TestUtils(unittest.TestCase):
+
+    @mock.patch.object(hookenv, 'config')
+    def test_endpoint_type(self, mock_config):
+        mock_config.return_value = False
+        self.assertEquals('publicURL', utils.endpoint_type())
+
+        mock_config.return_value = True
+        self.assertEquals('internalURL', utils.endpoint_type())
+
+    @mock.patch.object(utils, 'ks_session')
+    @mock.patch.object(utils, 'ks_identity')
+    def test_get_session_from_keystone(self, mock_identity, mock_session):
+        mock_ks = mock.Mock()
+
+        result = utils.get_session_from_keystone(mock_ks)
+
+        self.assertEqual(mock_session.Session.return_value, result)
+        expected_auth_url = "%s://%s:%s/" % (
+            mock_ks.auth_protocol.return_value,
+            mock_ks.auth_host.return_value,
+            mock_ks.auth_port.return_value,
+        )
+        mock_identity.Password.assert_called_once_with(
+            auth_url=expected_auth_url,
+            user_domain_name=mock_ks.service_domain.return_value,
+            username=mock_ks.service_username.return_value,
+            password=mock_ks.service_password.return_value,
+            project_domain_name=mock_ks.service_domain.return_value,
+            project_name=mock_ks.service_tenant.return_value,
+        )
+        mock_session.Session.assert_called_once_with(
+            auth=mock_identity.Password.return_value,
+            verify=utils.SYSTEM_CA_BUNDLE,
+        )
+
+    @mock.patch.object(utils, 'endpoint_type')
+    @mock.patch.object(hookenv, 'config')
+    @mock.patch.object(utils, 'neutron_client')
+    def test_get_neutron_client(self, mock_nc, mock_config, mock_endpoint):
+        client = utils.get_neutron_client(mock.sentinel.session)
+
+        self.assertEqual(mock_nc.Client.return_value, client)
+        mock_config.assert_called_once_with('region')
+        mock_nc.Client.assert_called_once_with(
+            session=mock.sentinel.session,
+            region_name=mock_config.return_value,
+            endpoint_type=mock_endpoint.return_value,
+        )
+
+    @mock.patch.object(utils, '_get_or_create_subnet')
+    @mock.patch.object(utils, '_get_or_create_network')
+    @mock.patch.object(utils, 'get_neutron_client')
+    @mock.patch.object(utils, 'get_session_from_keystone')
+    def test_create_trove_mgmt_network(
+            self, mock_get_sess, mock_get_nc, mock_get_net, mock_get_subnet):
+        mock_get_net.return_value = {'id': mock.sentinel.id}
+
+        net_id = utils.create_trove_mgmt_network(
+            mock.sentinel.keystone,
+            mock.sentinel.physnet,
+            mock.sentinel.cidr,
+            mock.sentinel.dest_cidr,
+            mock.sentinel.nexthop,
+        )
+
+        self.assertEqual(mock.sentinel.id, net_id)
+        mock_get_sess.assert_called_once_with(mock.sentinel.keystone)
+        mock_client = mock_get_nc.return_value
+        mock_get_nc.assert_called_once_with(mock_get_sess.return_value)
+        mock_get_net.assert_called_once_with(
+            mock_client, mock.sentinel.physnet)
+        mock_get_subnet.assert_called_once_with(
+            mock_client, mock.sentinel.id, mock.sentinel.cidr,
+            mock.sentinel.dest_cidr, mock.sentinel.nexthop)
+
+    def test_get_or_create_network_decorator(self):
+        mock_client = mock.Mock()
+        mock_client.list_networks.side_effect = ks_exc.catalog.EndpointNotFound
+
+        self.assertRaises(
+            exceptions.APIException,
+            utils._get_or_create_network,
+            mock_client,
+            mock.sentinel.physnet,
+        )
+
+    def test_get_or_create_network_exc(self):
+        mock_client = mock.Mock()
+        mock_client.list_networks.return_value = {
+            'networks': [mock.sentinel.network] * 2,
+        }
+
+        self.assertRaises(
+            exceptions.DuplicateResource,
+            utils._get_or_create_network,
+            mock_client,
+            mock.sentinel.physnet,
+        )
+        mock_client.list_networks.assert_called_once_with(tags=utils.TROVE_TAG)
+
+        fake_net = {
+            'id': mock.sentinel.id,
+            'provider:physical_network': mock.sentinel.other_physnet,
+        }
+        mock_client.list_networks.return_value = {'networks': [fake_net]}
+
+        self.assertRaises(
+            exceptions.InvalidResource,
+            utils._get_or_create_network,
+            mock_client,
+            mock.sentinel.physnet,
+        )
+
+    @mock.patch.object(utils, '_create_network')
+    def test_get_or_create_network(self, mock_create_net):
+        mock_client = mock.Mock()
+        fake_net = {
+            'id': mock.sentinel.id,
+            'provider:physical_network': mock.sentinel.physnet,
+        }
+        mock_client.list_networks.return_value = {'networks': [fake_net]}
+
+        network = utils._get_or_create_network(
+            mock_client, mock.sentinel.physnet)
+
+        self.assertEqual(fake_net, network)
+
+        mock_client.list_networks.return_value = {'networks': []}
+        network = utils._get_or_create_network(
+            mock_client, mock.sentinel.physnet)
+        self.assertEqual(mock_create_net.return_value, network)
+        mock_create_net.assert_called_once_with(
+            mock_client, mock.sentinel.physnet)
+
+    def test_create_network(self):
+        mock_client = mock.Mock()
+        fake_network = {'id': mock.sentinel.net_id}
+        mock_client.create_network.return_value = {'network': fake_network}
+
+        network = utils._create_network(mock_client, mock.sentinel.physnet)
+
+        self.assertEqual(fake_network, network)
+        expected_params = {
+            'name': utils.TROVE_MGMT_NET,
+            'provider:network_type': 'flat',
+            'provider:physical_network': mock.sentinel.physnet,
+            'shared': True,
+            'description': 'Trove management network',
+        }
+        mock_client.create_network.assert_called_once_with(
+            {'network': expected_params})
+        mock_client.add_tag.assert_called_once_with(
+            'networks', mock.sentinel.net_id, utils.TROVE_TAG)
+
+    def test_get_or_create_subnet_exc(self):
+        mock_client = mock.Mock()
+        fake_subnet = {'id': mock.sentinel.id, 'cidr': '192.168.1.0/24'}
+        mock_client.list_subnets.return_value = {'subnets': [fake_subnet]}
+
+        self.assertRaises(
+            exceptions.InvalidResource,
+            utils._get_or_create_subnet,
+            mock_client,
+            mock.sentinel.net_id,
+            '10.10.10.0/24',
+            mock.sentinel.dest_cidr,
+            mock.sentinel.nexthop,
+        )
+        mock_client.list_subnets.assert_called_once_with(
+            network_id=mock.sentinel.net_id)
+
+    @mock.patch.object(utils, '_update_route')
+    @mock.patch.object(utils, '_create_subnet')
+    def test_get_or_create_subnet(self, mock_create_subnet, mock_update_route):
+        mock_client = mock.Mock()
+        fake_cidr = '192.168.1.0/24'
+        fake_subnet = {'cidr': fake_cidr}
+
+        mock_client.list_subnets.return_value = {
+            'subnets': [fake_subnet],
+        }
+        subnet = utils._get_or_create_subnet(
+            mock_client, mock.sentinel.net_id, fake_cidr,
+            mock.sentinel.dest_cidr, mock.sentinel.nexthop)
+        self.assertEqual(fake_subnet, subnet)
+        mock_update_route.assert_called_once_with(
+            mock_client, subnet, mock.sentinel.dest_cidr,
+            mock.sentinel.nexthop)
+
+        mock_client.list_subnets.return_value = {'subnets': []}
+        subnet = utils._get_or_create_subnet(
+            mock_client, mock.sentinel.net_id, mock.sentinel.cidr,
+            mock.sentinel.dest_cidr, mock.sentinel.nexthop)
+        self.assertEqual(mock_create_subnet.return_value, subnet)
+        mock_create_subnet.assert_called_once_with(
+            mock_client, mock.sentinel.net_id, mock.sentinel.cidr,
+            mock.sentinel.dest_cidr, mock.sentinel.nexthop)
+
+    def test_create_subnet(self):
+        mock_client = mock.Mock()
+        mock_client.create_subnet.return_value = {
+            'subnets': [mock.sentinel.subnet],
+        }
+
+        subnet = utils._create_subnet(
+            mock_client, mock.sentinel.net_id, mock.sentinel.cidr,
+            mock.sentinel.dest_cidr, mock.sentinel.nexthop)
+
+        self.assertEqual(mock.sentinel.subnet, subnet)
+        expected_route = {
+            'destination': mock.sentinel.dest_cidr,
+            'nexthop': mock.sentinel.nexthop,
+        }
+        expected_params = {
+            'name': f"{utils.TROVE_MGMT_SUBNET}-v4",
+            'network_id': mock.sentinel.net_id,
+            'ip_version': 4,
+            'cidr': mock.sentinel.cidr,
+            'gateway_ip': None,
+            'description': 'Trove management subnet',
+            'host_routes': [expected_route],
+        }
+        mock_client.create_subnet.assert_called_once_with(
+            {'subnets': [expected_params]})
+
+    def test_update_route_already_exists(self):
+        routes = [
+            {'destination': mock.sentinel.other, 'nexthop': mock.sentinel.hop},
+            {'destination': mock.sentinel.dest, 'nexthop': mock.sentinel.hop},
+        ]
+        subnet = {
+            'id': mock.sentinel.id,
+            'name': mock.sentinel.name,
+            'host_routes': routes,
+        }
+        mock_client = mock.Mock()
+
+        utils._update_route(mock_client, subnet, mock.sentinel.dest,
+                            mock.sentinel.hop)
+
+        mock_client.update_subnet.assert_not_called()
+
+    def test_update_route(self):
+        mock_client = mock.Mock()
+        existing_route = {
+            'destination': mock.sentinel.dest_cidr,
+            'nexthop': mock.sentinel.otherhop,
+        }
+        subnet = {
+            'name': mock.sentinel.name,
+            'id': mock.sentinel.id,
+            'host_routes': [existing_route],
+        }
+
+        utils._update_route(mock_client, subnet, mock.sentinel.dest_cidr,
+                            mock.sentinel.nexthop)
+
+        # Assert that the old route has been removed.
+        expected_routes = {
+            'host_routes': [{
+                'destination': mock.sentinel.dest_cidr,
+                'nexthop': mock.sentinel.nexthop,
+            }],
+        }
+        mock_client.update_subnet.assert_called_once_with(
+            mock.sentinel.id, {'subnet': expected_routes})


### PR DESCRIPTION
Adds the ``create-management-network`` juju action, which will create the Neutron network, subnet, router and additional routes needed for the Trove instances to connect to the RabbitMQ on the Management Network.