### PR TITLE
Create and manage a Security Group for Trove instances by default

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -110,6 +110,9 @@ sudo snap install --classic charm
 git clone https://github.com/cloudbase/trove-charm
 cd trove-charm
 
+# Install dependencies required to build the charm wheels.
+sudo apt install libffi-dev libssl-dev
+
 # Build the charm.
 charm build src
 ```
@@ -214,7 +217,9 @@ become active. It needs to be set to the Neutron network created in the
 juju config trove management-networks=$TROVE_NET_UID
 ```
 
-A management Neutron security group can be created and assigned to the
+By default, the Trove charm will create and manage a management Neutron security
+group containing only egress rules for the related RabbitMQ units. Alternatively,
+a management Neutron security group can be created and assigned to the
 management ports of the Trove instances by setting the ``management-security-groups``
 config option:
 

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -47,6 +47,9 @@ options:
     description: |
       Comma-separated list of the security group IDs that are applied on the
       management port of the database instance.
+      If not set, the charm will automatically create a Security Group containing
+      only egress rules to the related RabbitMQ units, through which the Trove
+      database instances will communicate with the Trove API.
   ip-regex:
     type: string
     default: ""

--- a/src/layer.yaml
+++ b/src/layer.yaml
@@ -11,3 +11,4 @@ options:
   basic:
     use_venv: True
     include_system_packages: True
+    python_packages: ['python-keystoneclient', 'python-neutronclient']

--- a/src/lib/charm/openstack/exceptions.py
+++ b/src/lib/charm/openstack/exceptions.py
@@ -1,0 +1,70 @@
+# Copyright 2023 Cloudbase Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from keystoneauth1 import exceptions as ks_exc
+from neutronclient.common import exceptions as neutron_exc
+
+
+NEUTRON_EXCS = (
+    ks_exc.catalog.EndpointNotFound,
+    ks_exc.connection.ConnectFailure,
+    ks_exc.discovery.DiscoveryFailure,
+    ks_exc.http.ServiceUnavailable,
+    ks_exc.http.InternalServerError,
+    neutron_exc.ServiceUnavailable,
+    neutron_exc.BadRequest,
+    neutron_exc.NeutronClientException,
+)
+
+
+class TroveCharmException(Exception):
+
+    msg_fmt = 'An exception occured.'
+
+    def __init__(self, msg=None, **kwargs):
+        self.kwargs = kwargs
+
+        if not msg:
+            msg = self.msg_fmt % kwargs
+        else:
+            msg = str(msg)
+
+        self.msg = msg
+        super().__init__(msg)
+
+
+class DuplicateResource(TroveCharmException):
+    msg_fmt = "A duplicate '%(resource_type)s' has been found: %(data)s"
+
+    def __init__(self, msg=None, resource_type=None, data=None):
+        super().__init__(msg, resource_type=resource_type, data=data)
+        self.resource_type = resource_type
+
+
+class InvalidResource(TroveCharmException):
+    msg_fmt = ("Invalid %(resource_type)s with id %(id)s found. "
+               "Details: %(details)s")
+
+    def __init__(self, msg=None, resource_type=None, id=None, details=None):
+        super().__init__(msg, resource_type=resource_type, id=id,
+                         details=details)
+
+
+class APIException(TroveCharmException):
+    msg_fmt = ("An error occured while accessing the %(service)s "
+               "%(resource_type)s API. Exception: %(exc)s")
+
+    def __init__(self, msg=None, service=None, resource_type=None, exc=None):
+        super().__init__(msg, service=service, resource_type=resource_type,
+                         exc=exc)

--- a/src/lib/charm/openstack/trove.py
+++ b/src/lib/charm/openstack/trove.py
@@ -4,6 +4,9 @@ import os
 import charmhelpers.core.hookenv as hookenv
 import charms_openstack.charm
 import charms_openstack.ip as os_ip
+import charms.reactive as reactive
+
+from charm.openstack import utils
 
 
 PACKAGES = [
@@ -26,6 +29,24 @@ TROVE_PASTE_API = os.path.join(TROVE_DIR, 'api-paste.ini')
 
 # select the default release function
 charms_openstack.charm.use_defaults('charm.default-select-release')
+
+
+@charms_openstack.adapters.config_property
+def trove_security_group(cls):
+    """Returns the Trove Management Network Security Group ID.
+
+    Config property adapter which returns the Security Group ID set in the
+    `management-security-groups` config option, or the ID of the Security
+    Group created by the Trove charm (tagged with `charm-trove`).
+    """
+    config = hookenv.config('management-security-groups')
+    if config:
+        return config
+
+    # If the config option was not set, use the Security Group created by
+    # the charm.
+    keystone = reactive.endpoint_from_flag('identity-service.available')
+    return utils.get_trove_mgmt_sec_group(keystone)
 
 
 class TroveCharm(charms_openstack.charm.HAOpenStackCharm):

--- a/src/lib/charm/openstack/utils.py
+++ b/src/lib/charm/openstack/utils.py
@@ -1,0 +1,180 @@
+# Copyright 2023 Cloudbase Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+from charmhelpers.core import hookenv
+from keystoneauth1 import identity as ks_identity
+from keystoneauth1 import session as ks_session
+from neutronclient.v2_0 import client as neutron_client
+
+from charm.openstack import exceptions
+
+
+SYSTEM_CA_BUNDLE = '/etc/ssl/certs/ca-certificates.crt'
+TROVE_MGMT_SG = 'trove-sec-group'
+TROVE_TAG = 'charm-trove'
+
+
+def api_exc_wrapper(exc_list, service, resource_type):
+    def decorator(func):
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except exc_list as exc:
+                raise exceptions.APIException(
+                    service=service, resource_type=resource_type, exc=exc)
+        return inner
+    return decorator
+
+
+def endpoint_type():
+    if hookenv.config('use-internal-endpoints'):
+        return 'internalURL'
+    return 'publicURL'
+
+
+def get_session_from_keystone(keystone):
+    protocol = keystone.auth_protocol()
+    host = keystone.auth_host()
+    port = keystone.auth_port()
+    auth_url = f"{protocol}://{host}:{port}/"
+    auth = ks_identity.Password(
+        auth_url=auth_url,
+        username=keystone.service_username(),
+        password=keystone.service_password(),
+        project_name=keystone.service_tenant(),
+        user_domain_name=keystone.service_domain(),
+        project_domain_name=keystone.service_domain(),
+    )
+    return ks_session.Session(auth=auth, verify=SYSTEM_CA_BUNDLE)
+
+
+def get_neutron_client(session):
+    return neutron_client.Client(
+        session=session, region_name=hookenv.config('region'),
+        endpoint_type=endpoint_type(),
+    )
+
+
+def get_trove_mgmt_sec_group(keystone):
+    """Returns the ID of the Trove Management Network Security Group.
+
+    Returns the Security Group ID tagged with `charm-trove`. If it doesn't
+    exist, it will be created.
+    """
+    session = get_session_from_keystone(keystone)
+    client = get_neutron_client(session)
+
+    sec_group = _get_or_create_sec_group(client)
+    return sec_group['id']
+
+
+def update_trove_mgmt_sec_group(keystone, rabbitmq_ips, rabbitmq_port):
+    """Updates Trove Management Network Security Group and returns its ID.
+
+    Creates the Trove Management Network Security Group if it doesn't exist,
+    removing its default egress rules, and updates the Security Group to
+    contain egress rules for the given RabbitMQ IPs.
+    """
+    session = get_session_from_keystone(keystone)
+    client = get_neutron_client(session)
+
+    sec_group = _get_or_create_sec_group(client)
+    egress_rules = [rule for rule in sec_group['security_group_rules'] if
+                    rule['direction'] == 'egress' and
+                    rule['ethertype'] == 'IPv4' and
+                    rule['protocol'] == 'tcp']
+
+    # Get the IPs for which we should add egress rules for.
+    ips_to_add = []
+    for ip in rabbitmq_ips:
+        found = False
+        for rule in egress_rules:
+            if (rule['remote_ip_prefix'] == ip and
+                    rule['port_range_min'] == rabbitmq_port):
+                found = True
+                break
+
+        if not found:
+            ips_to_add.append(ip)
+
+    for ip in ips_to_add:
+        _create_sec_group_rule(client, sec_group['id'], 'egress', 'tcp',
+                               ip, rabbitmq_port)
+
+    # Delete egress rules that do not apply for the current IPs.
+    rules_to_delete = [rule for rule in egress_rules if
+                       rule['port_range_min'] != rabbitmq_port or
+                       rule['remote_ip_prefix'] not in rabbitmq_ips]
+    for rule in rules_to_delete:
+        client.delete_security_group_rule(rule['id'])
+
+    return sec_group['id']
+
+
+@api_exc_wrapper(exceptions.NEUTRON_EXCS, 'neutron', 'security_group')
+def _get_or_create_sec_group(client):
+    resp = client.list_security_groups(tags=TROVE_TAG)
+    sec_groups = resp.get('security_groups', [])
+    if len(sec_groups) > 1:
+        raise exceptions.DuplicateResource('security-group', sec_groups)
+
+    if sec_groups:
+        return sec_groups[0]
+
+    # Create the security group only if it doesn't exist.
+    sec_group = _create_sec_group(client)
+
+    # Delete the default rules.
+    for rule in sec_group['security_group_rules']:
+        client.delete_security_group_rule(rule['id'])
+
+    # We removed the rules.
+    sec_group['security_group_rules'] = []
+
+    return sec_group
+
+
+def _create_sec_group(client):
+    params = {
+        'name': TROVE_MGMT_SG,
+        'description': 'Trove management network security group',
+    }
+    resp = client.create_security_group({'security_group': params})
+    sec_group = resp['security_group']
+
+    # We cannot add tags during creation.
+    client.add_tag('security-groups', sec_group['id'], TROVE_TAG)
+
+    return sec_group
+
+
+@api_exc_wrapper(exceptions.NEUTRON_EXCS, 'neutron', 'security_group_rule')
+def _create_sec_group_rule(client, sec_group_id, direction, protocol=None,
+                           remote_ip=None, port_min=None, port_max=None):
+    port_max = port_max or port_min
+
+    params = {
+        'security_group_id': sec_group_id,
+        'direction': direction,
+        'protocol': protocol,
+        'ethertype': 'IPv4',
+        'remote_ip_prefix': remote_ip,
+        'port_range_min': port_min,
+        'port_range_max': port_max,
+    }
+
+    client.create_security_group_rule({'security_group_rule': params})

--- a/src/reactive/trove_handlers.py
+++ b/src/reactive/trove_handlers.py
@@ -12,12 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from charmhelpers.core import hookenv
 import charms_openstack.charm as charm
+import charms.leadership as leadership
 import charms.reactive as reactive
 
 # This charm's library contains all of the handler code associated with
 # the Trove Charm
+from charm.openstack import exceptions
 import charm.openstack.trove as trove  # noqa
+from charm.openstack import utils
+
+
+AMQP_DEFAULT_PORT = 5672
 
 
 # Use the charms.openstack defaults for common states and hooks
@@ -34,19 +41,86 @@ charm.use_defaults(
 )
 
 
+@reactive.when('leadership.is_leader')
+@reactive.when('identity-service.available')
+@reactive.when('amqp.available')
+@reactive.when_not('is-update-status-hook')
+@reactive.when_not('unit.is-departing')
+def update_security_group(*args):
+    """Optionally creates and updates the Trove Management Security Group.
+
+    If a Security Group is not specified through the management-security-groups
+    config option, this will create a Security Group and update its egress
+    rules to allow only RabbitMQ.
+    """
+    config = hookenv.config('management-security-groups')
+    if config:
+        # Skip creating a new security group, we already have one configured.
+        leadership.leader_set({'security-group-updated': True})
+        return
+
+    departing_unit = hookenv.departing_unit()
+    if departing_unit:
+        name = charm.get_charm_instance().configuration_class().local_unit_name
+        departing_unit = departing_unit.replace('/', '-')
+        if departing_unit == name:
+            reactive.set_flag('unit.is-departing')
+            return
+
+    amqp = reactive.endpoint_from_flag('amqp.available')
+    rabbitmq_ips = [f'{ip}/32' for ip in amqp.rabbitmq_hosts()]
+    rabbitmq_port = amqp.ssl_port() or AMQP_DEFAULT_PORT
+
+    keystone = reactive.endpoint_from_flag('identity-service.available')
+    try:
+        utils.update_trove_mgmt_sec_group(
+            keystone, rabbitmq_ips, rabbitmq_port)
+    except exceptions.DuplicateResource as ex:
+        hookenv.log(
+            f"The '{ex.resource_type}' to be created by this action was "
+            "already duplicated. This will have to be cleaned up manually."
+            "Exception: {ex}"
+        )
+        return
+    except exceptions.APIException as ex:
+        hookenv.log(
+            "Encountered exception while updating the Trove management "
+            f"network security group. Deferring. Exception: {ex}"
+        )
+        return
+
+    leadership.leader_set({'security-group-updated': True})
+
+
 @reactive.when('shared-db.available')
 @reactive.when('identity-service.available')
 @reactive.when('amqp.available')
+@reactive.when('leadership.set.security-group-updated')
 @reactive.when_not('is-update-status-hook')
 def render_config(*args):
     """Render the configuration for charm when all the interfaces are
     available.
     """
     with charm.provide_charm_instance() as charm_class:
-        charm_class.upgrade_if_available(args)
-        charm_class.render_with_interfaces(args)
-        charm_class.configure_ssl()
-        charm_class.assess_status()
+        try:
+            charm_class.upgrade_if_available(args)
+            charm_class.render_with_interfaces(args)
+            charm_class.configure_ssl()
+            charm_class.assess_status()
+        except exceptions.DuplicateResource as ex:
+            hookenv.log(
+                f"The '{ex.resource_type}' to be created by this action was "
+                "already duplicated. This will have to be cleaned up manually."
+                "Exception: {ex}"
+            )
+            return
+        except exceptions.APIException as ex:
+            hookenv.log(
+                "Encountered exception while updating the Trove management "
+                f"network security group. Deferring. Exception: {ex}"
+            )
+            return
+
     reactive.set_state('config.rendered')
 
 

--- a/src/templates/antelope/trove.conf
+++ b/src/templates/antelope/trove.conf
@@ -8,8 +8,8 @@ docker_insecure_registries =
 network_driver = trove.network.neutron.NeutronDriver
 management_networks = {{ options.management_networks }}
 
-{% if options.management_security_groups -%}
-management_security_groups = {{ options.management_security_groups }}
+{% if options.trove_security_group -%}
+management_security_groups = {{ options.trove_security_group }}
 {% endif -%}
 
 {% if options.ip_regex -%}

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -2,5 +2,7 @@ flit_scm
 anyio<3.7.0
 Cython<3.0
 
+dnspython<2.3.0
+
 git+https://github.com/openstack/charms.openstack.git#egg=charms.openstack
 git+https://github.com/juju/charm-helpers.git#egg=charmhelpers

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,3 +9,5 @@ coverage>=3.6
 git+https://github.com/openstack/charms.openstack#egg=charms.openstack
 
 oslotest>=3.8.0
+keystoneauth1>=3.16.0
+python-neutronclient>=3.1.0,<4.0

--- a/tox.ini
+++ b/tox.ini
@@ -55,4 +55,5 @@ commands = {posargs}
 
 [flake8]
 # E402 ignore necessary for path append before sys module import in actions
-ignore = E402
+# W504 - line break after binary operator
+ignore = E402,W504

--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -33,3 +33,6 @@ charms_openstack.test_mocks.mock_charmhelpers()
 
 apt_pkg = mock.MagicMock()
 sys.modules['apt_pkg'] = apt_pkg
+
+charms = mock.MagicMock()
+sys.modules['charms.leadership'] = charms.leadership

--- a/unit_tests/base.py
+++ b/unit_tests/base.py
@@ -1,0 +1,25 @@
+# Copyright 2023 Cloudbase Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+
+class TestBase(unittest.TestCase):
+    def _patch(self, thing, member):
+        patcher = mock.patch.object(thing, member)
+        mocked = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        return mocked

--- a/unit_tests/test_lib_charm_openstack_trove.py
+++ b/unit_tests/test_lib_charm_openstack_trove.py
@@ -1,0 +1,38 @@
+# Copyright 2023 Cloudbase Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from charm.openstack import trove
+
+
+class TestTrove(unittest.TestCase):
+
+    @mock.patch.object(trove.utils, 'get_trove_mgmt_sec_group')
+    @mock.patch.object(trove.reactive, 'endpoint_from_flag')
+    @mock.patch.object(trove.hookenv, 'config')
+    def test_trove_security_group(self, mock_config, mock_endpoint_from_flag,
+                                  mock_get_trove_sg):
+        mock_config.return_value = mock.sentinel.set_config
+        self.assertEquals(mock.sentinel.set_config,
+                          trove.trove_security_group(mock.sentinel.cls))
+
+        mock_config.return_value = None
+        self.assertEquals(mock_get_trove_sg.return_value,
+                          trove.trove_security_group(mock.sentinel.cls))
+        mock_endpoint_from_flag.assert_called_once_with(
+            'identity-service.available')
+        mock_get_trove_sg.assert_called_once_with(
+            mock_endpoint_from_flag.return_value)

--- a/unit_tests/test_lib_charm_openstack_utils.py
+++ b/unit_tests/test_lib_charm_openstack_utils.py
@@ -1,0 +1,259 @@
+# Copyright 2023 Cloudbase Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from charmhelpers.core import hookenv
+
+from charm.openstack import exceptions
+from charm.openstack import utils
+
+
+class TestUtils(unittest.TestCase):
+
+    @mock.patch.object(hookenv, 'config')
+    def test_endpoint_type(self, mock_config):
+        mock_config.return_value = False
+        self.assertEquals('publicURL', utils.endpoint_type())
+
+        mock_config.return_value = True
+        self.assertEquals('internalURL', utils.endpoint_type())
+
+    @mock.patch.object(utils, 'ks_session')
+    @mock.patch.object(utils, 'ks_identity')
+    def test_get_session_from_keystone(self, mock_identity, mock_session):
+        mock_ks = mock.Mock()
+
+        result = utils.get_session_from_keystone(mock_ks)
+
+        self.assertEqual(mock_session.Session.return_value, result)
+        expected_auth_url = "%s://%s:%s/" % (
+            mock_ks.auth_protocol.return_value,
+            mock_ks.auth_host.return_value,
+            mock_ks.auth_port.return_value,
+        )
+        mock_identity.Password.assert_called_once_with(
+            auth_url=expected_auth_url,
+            user_domain_name=mock_ks.service_domain.return_value,
+            username=mock_ks.service_username.return_value,
+            password=mock_ks.service_password.return_value,
+            project_domain_name=mock_ks.service_domain.return_value,
+            project_name=mock_ks.service_tenant.return_value,
+        )
+        mock_session.Session.assert_called_once_with(
+            auth=mock_identity.Password.return_value,
+            verify=utils.SYSTEM_CA_BUNDLE,
+        )
+
+    @mock.patch.object(utils, 'endpoint_type')
+    @mock.patch.object(hookenv, 'config')
+    @mock.patch.object(utils, 'neutron_client')
+    def test_get_neutron_client(self, mock_nc, mock_config, mock_endpoint):
+        client = utils.get_neutron_client(mock.sentinel.session)
+
+        self.assertEqual(mock_nc.Client.return_value, client)
+        mock_config.assert_called_once_with('region')
+        mock_nc.Client.assert_called_once_with(
+            session=mock.sentinel.session,
+            region_name=mock_config.return_value,
+            endpoint_type=mock_endpoint.return_value,
+        )
+
+    @mock.patch.object(utils, '_get_or_create_sec_group')
+    @mock.patch.object(utils, 'get_neutron_client')
+    @mock.patch.object(utils, 'get_session_from_keystone')
+    def test_get_trove_mgmt_sec_group(
+            self, mock_get_sess, mock_get_nc, mock_get_sg):
+        mock_get_sg.return_value = {'id': mock.sentinel.group_id}
+
+        sec_group_id = utils.get_trove_mgmt_sec_group(mock.sentinel.keystone)
+
+        self.assertEqual(mock.sentinel.group_id, sec_group_id)
+        mock_get_sess.assert_called_once_with(mock.sentinel.keystone)
+        mock_client = mock_get_nc.return_value
+        mock_get_nc.assert_called_once_with(mock_get_sess.return_value)
+        mock_get_sg.assert_called_once_with(mock_client)
+
+    @mock.patch.object(utils, '_create_sec_group_rule')
+    @mock.patch.object(utils, '_get_or_create_sec_group')
+    @mock.patch.object(utils, 'get_neutron_client')
+    @mock.patch.object(utils, 'get_session_from_keystone')
+    def test_update_trove_mgmt_sec_group(
+            self, mock_get_sess, mock_get_nc, mock_get_sg,
+            mock_create_sg_rule):
+        # The tested function should:
+        # - remove a rule that is no longer needed.
+        # - remove a rule with a different port and add a new one.
+        # - add a new rule for the new IP.
+        # - leave the rest of the rules untouched.
+        old_sec_group_rules = [
+            {
+                'id': mock.sentinel.id1,
+                'direction': 'egress',
+                'ethertype': 'IPv4',
+                'protocol': 'tcp',
+                'remote_ip_prefix': mock.sentinel.ip1,
+                'port_range_min': mock.sentinel.port,
+            },
+            {
+                'id': mock.sentinel.id2,
+                'direction': 'egress',
+                'ethertype': 'IPv4',
+                'protocol': 'tcp',
+                'remote_ip_prefix': mock.sentinel.ip2,
+                'port_range_min': mock.sentinel.otherport,
+            },
+            {
+                'id': mock.sentinel.id3,
+                'direction': 'egress',
+                'ethertype': 'IPv4',
+                'protocol': 'tcp',
+                'remote_ip_prefix': mock.sentinel.ip3,
+                'port_range_min': mock.sentinel.port,
+            },
+            {
+                'id': mock.sentinel.id4,
+                'direction': 'ingress',
+                'ethertype': 'IPv4',
+                'protocol': 'tcp',
+                'remote_ip_prefix': mock.sentinel.ip4,
+            },
+            {
+                'id': mock.sentinel.id5,
+                'direction': 'egress',
+                'ethertype': 'IPv6',
+                'protocol': 'tcp',
+                'remote_ip_prefix': mock.sentinel.ip5,
+            },
+            {
+                'id': mock.sentinel.id6,
+                'direction': 'egress',
+                'ethertype': 'IPv4',
+                'protocol': 'udp',
+                'remote_ip_prefix': mock.sentinel.ip6,
+            },
+        ]
+        mock_get_sg.return_value = {
+            'id': mock.sentinel.group_id,
+            'security_group_rules': old_sec_group_rules,
+        }
+        new_rabbitmq_ips = [mock.sentinel.ip2, mock.sentinel.ip3,
+                            mock.sentinel.ipnew]
+
+        sec_group_id = utils.update_trove_mgmt_sec_group(
+            mock.sentinel.keystone,
+            new_rabbitmq_ips,
+            mock.sentinel.port,
+        )
+
+        self.assertEqual(mock.sentinel.group_id, sec_group_id)
+        mock_get_sess.assert_called_once_with(mock.sentinel.keystone)
+        mock_client = mock_get_nc.return_value
+        mock_get_nc.assert_called_once_with(mock_get_sess.return_value)
+        mock_get_sg.assert_called_once_with(mock_client)
+        mock_create_sg_rule.assert_has_calls([
+            mock.call(mock_client, mock.sentinel.group_id, 'egress', 'tcp',
+                      mock.sentinel.ip2, mock.sentinel.port),
+            mock.call(mock_client, mock.sentinel.group_id, 'egress', 'tcp',
+                      mock.sentinel.ipnew, mock.sentinel.port),
+        ])
+        mock_client.delete_security_group_rule.assert_has_calls([
+            mock.call(mock.sentinel.id1),
+            mock.call(mock.sentinel.id2),
+        ])
+
+    def test_get_or_create_sec_group_exc(self):
+        mock_client = mock.Mock()
+        mock_client.list_security_groups.return_value = {
+            'security_groups': [mock.sentinel.sec_group] * 2,
+        }
+
+        self.assertRaises(
+            exceptions.DuplicateResource,
+            utils._get_or_create_sec_group,
+            mock_client,
+        )
+        mock_client.list_security_groups.assert_called_once_with(
+            tags=utils.TROVE_TAG)
+
+    @mock.patch.object(utils, '_create_sec_group')
+    def test_get_or_create_sec_group(self, mock_create_sec_group):
+        mock_client = mock.Mock()
+        mock_client.list_security_groups.return_value = {
+            'security_groups': [mock.sentinel.group],
+        }
+
+        sec_group = utils._get_or_create_sec_group(mock_client)
+
+        self.assertEqual(mock.sentinel.group, sec_group)
+
+        mock_client.list_security_groups.return_value = {
+            'security_groups': [],
+        }
+        fake_sec_group_rule = {'id': mock.sentinel.rule_id}
+        fake_sec_group = {
+            'security_group_rules': [fake_sec_group_rule] * 2,
+        }
+        mock_create_sec_group.return_value = fake_sec_group
+
+        sec_group = utils._get_or_create_sec_group(mock_client)
+
+        self.assertEqual(fake_sec_group, sec_group)
+        self.assertListEqual([], fake_sec_group['security_group_rules'])
+        mock_client.delete_security_group_rule.assert_has_calls(
+            [mock.call(mock.sentinel.rule_id)] * 2)
+        mock_create_sec_group.assert_called_once_with(mock_client)
+
+    def test_create_sec_group(self):
+        mock_client = mock.Mock()
+        fake_sec_group = {'id': mock.sentinel.sec_group_id}
+        mock_client.create_security_group.return_value = {
+            'security_group': fake_sec_group}
+
+        sec_group = utils._create_sec_group(mock_client)
+
+        self.assertEqual(fake_sec_group, sec_group)
+        expected_params = {
+            'name': utils.TROVE_MGMT_SG,
+            'description': 'Trove management network security group',
+        }
+        mock_client.create_security_group.assert_called_once_with(
+            {'security_group': expected_params})
+        mock_client.add_tag.assert_called_once_with(
+            'security-groups', mock.sentinel.sec_group_id, utils.TROVE_TAG)
+
+    def test_create_sec_group_rule(self):
+        mock_client = mock.Mock()
+
+        utils._create_sec_group_rule(
+            mock_client,
+            mock.sentinel.sec_group_id,
+            mock.sentinel.direction,
+            mock.sentinel.protocol,
+            mock.sentinel.remote_ip,
+            mock.sentinel.port_min,
+        )
+
+        expected_params = {
+            'security_group_id': mock.sentinel.sec_group_id,
+            'direction': mock.sentinel.direction,
+            'protocol': mock.sentinel.protocol,
+            'ethertype': 'IPv4',
+            'remote_ip_prefix': mock.sentinel.remote_ip,
+            'port_range_min': mock.sentinel.port_min,
+            'port_range_max': mock.sentinel.port_min,
+        }
+        mock_client.create_security_group_rule.assert_called_once_with(
+            {'security_group_rule': expected_params})

--- a/unit_tests/test_reactive_trove_handlers.py
+++ b/unit_tests/test_reactive_trove_handlers.py
@@ -1,0 +1,163 @@
+# Copyright 2023 Cloudbase Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+from charmhelpers.core import hookenv
+import charms_openstack.test_utils as test_utils
+
+from charm.openstack import exceptions
+import reactive.trove_handlers as handlers
+from unit_tests import base
+
+
+class TestRegisteredHooks(test_utils.TestRegisteredHooks):
+
+    def test_hooks(self):
+        defaults = [
+            'charm.installed',
+            'amqp.connected',
+            'shared-db.connected',
+            'identity-service.connected',
+            'config.changed',
+            'update-status',
+            'upgrade-charm',
+            'certificates.available',
+        ]
+        hook_set = {
+            'when': {
+                'update_security_group': (
+                    'leadership.is_leader',
+                    'identity-service.available',
+                    'amqp.available',
+                ),
+                'render_config': (
+                    'shared-db.available',
+                    'identity-service.available',
+                    'amqp.available',
+                    'leadership.set.security-group-updated',
+                ),
+                'init_db': ('config.rendered',),
+                'cluster_connected': ('ha.connected',),
+            },
+            'when_not': {
+                'update_security_group': (
+                    'is-update-status-hook',
+                    'unit.is-departing',
+                ),
+                'render_config': ('is-update-status-hook',),
+                'init_db': ('db.synced',),
+                'cluster_connected': ('ha.available', 'is-update-status-hook'),
+            },
+            'hook': {
+                'upgrade_charm': ('upgrade-charm',),
+            },
+        }
+        # test that the hooks were registered via the
+        # reactive.octavia_handlers
+        self.registered_hooks_test_helper(handlers, hook_set, defaults)
+
+
+class TestTroveHandlers(base.TestBase):
+
+    def setUp(self):
+        super().setUp()
+
+        self._hookenv = self._patch(handlers, 'hookenv')
+        self._reactive = self._patch(handlers, 'reactive')
+        self._leadership = self._patch(handlers, 'leadership')
+        self._trove_charm = mock.Mock()
+
+        provide_charm_inst = self._patch(handlers.charm,
+                                         'provide_charm_instance')
+        provide_charm_inst().__enter__.return_value = self._trove_charm
+        provide_charm_inst().__exit__.return_value = None
+
+    def test_update_security_group_skip(self):
+        handlers.update_security_group()
+
+        self._hookenv.config.assert_called_once_with(
+            'management-security-groups')
+        self._leadership.leader_set.assert_called_once_with(
+            {'security-group-updated': True})
+        self._reactive.endpoint_from_flag.assert_not_called()
+
+    def test_update_security_group_departing(self):
+        self._hookenv.config.return_value = ""
+        hookenv.local_unit.return_value = 'foo/0'
+        self._hookenv.departing_unit.return_value = 'foo/0'
+
+        handlers.update_security_group()
+
+        self._reactive.set_flag.assert_called_once_with('unit.is-departing')
+        self._reactive.endpoint_from_flag.assert_not_called()
+
+    def test_update_security_group(self):
+        self._test_update_security_group()
+
+    def test_update_security_group_duplicate(self):
+        self._test_update_security_group(
+            side_effect=exceptions.DuplicateResource)
+
+    def test_update_security_group_api_exc(self):
+        self._test_update_security_group(
+            side_effect=exceptions.APIException)
+
+    @mock.patch.object(handlers.utils, 'update_trove_mgmt_sec_group')
+    def _test_update_security_group(self, mock_update_trove_sg,
+                                    side_effect=None):
+        self._hookenv.config.return_value = ""
+        mock_amqp = mock.Mock()
+        mock_keystone = mock.Mock()
+        self._reactive.endpoint_from_flag.side_effect = [
+            mock_amqp, mock_keystone]
+        mock_amqp.rabbitmq_hosts.return_value = ['10.10.10.10']
+        mock_amqp.ssl_port.return_value = 9999
+        mock_update_trove_sg.side_effect = side_effect
+
+        handlers.update_security_group()
+
+        self._reactive.endpoint_from_flag.assert_has_calls([
+            mock.call('amqp.available'),
+            mock.call('identity-service.available')])
+        mock_update_trove_sg.assert_called_once_with(
+            mock_keystone, ['10.10.10.10/32'], 9999)
+        if side_effect:
+            self._hookenv.log.assert_called_once()
+        else:
+            self._leadership.leader_set.assert_called_once_with(
+                {'security-group-updated': True})
+
+    def test_render_config(self):
+        handlers.render_config(mock.sentinel.arg)
+
+        self._trove_charm.upgrade_if_available.assert_called_once_with(
+            (mock.sentinel.arg,))
+        self._trove_charm.render_with_interfaces.assert_called_once_with(
+            (mock.sentinel.arg,))
+        self._trove_charm.assess_status.assert_called_once_with()
+        self._reactive.set_state.assert_called_once_with('config.rendered')
+
+    def test_render_config_duplicate(self):
+        self._test_render_config(side_effect=exceptions.DuplicateResource)
+
+    def test_render_config_api_exc(self):
+        self._test_render_config(side_effect=exceptions.APIException)
+
+    def _test_render_config(self, side_effect):
+        self._trove_charm.upgrade_if_available.side_effect = side_effect
+        handlers.render_config()
+
+        self._hookenv.log.assert_called_once()
+        self._reactive.set_state.assert_not_called()


### PR DESCRIPTION
Currently, the charm can be configured with a Neutron Security Group through the `management-security-groups` config option, which is then conditionally added to the generated `trove.conf` file.

With this, if the config option is not set, the charm will create and manage a Security Group containing only egress rules for the related RabbitMQ units.