### PR TITLE
Fixes unittest github action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,4 +21,4 @@ jobs:
       - name: Install dependencies
         run: python3 -m pip install tox
       - name: Run tests
-        run: tox -vve py38
+        run: tox -vve unit

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 
 [tox]
 skipsdist = True
-envlist = pep8,py38
+envlist = pep8,unit
 skip_missing_interpreters = True
 
 [bundleenv]
@@ -40,8 +40,8 @@ basepython = python3
 commands =
     charm-build --log-level DEBUG -o {toxinidir}/build src {posargs}
 
-[testenv:py38]
-basepython = python3.8
+[testenv:unit]
+basepython = python3
 deps = -r{toxinidir}/test-requirements.txt
 commands = stestr run --slowest {posargs}
 


### PR DESCRIPTION
We're running Python 3.10 in the github action, while the tox target is specific to Python 3.8.

With this change, it should work for any Python version.