### PR TITLE
Adds charmcraft tox target

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,48 @@
+type: charm
+
+parts:
+  charm:
+    plugin: reactive
+    reactive-charm-build-arguments:
+      - --binary-wheels-from-source
+    build-packages:
+      - tox
+    source: src/
+    build-snaps:
+      - charm/latest/edge
+    build-environment:
+      - CHARM_INTERFACES_DIR: $CRAFT_PROJECT_DIR/interfaces/
+      - CHARM_LAYERS_DIR: $CRAFT_PROJECT_DIR/layers/
+bases:
+  - build-on:
+      - name: ubuntu
+        channel: "22.04"
+        architectures: [amd64]
+    run-on:
+      - name: ubuntu
+        channel: "22.04"
+        architectures: [amd64]
+  - build-on:
+      - name: ubuntu
+        channel: "22.04"
+        architectures: [s390x]
+    run-on:
+      - name: ubuntu
+        channel: "22.04"
+        architectures: [s390x]
+  - build-on:
+      - name: ubuntu
+        channel: "22.04"
+        architectures: [ppc64el]
+    run-on:
+      - name: ubuntu
+        channel: "22.04"
+        architectures: [ppc64el]
+  - build-on:
+      - name: ubuntu
+        channel: "22.04"
+        architectures: [arm64]
+    run-on:
+      - name: ubuntu
+        channel: "22.04"
+        architectures: [arm64]

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,1 @@
+src/metadata.yaml

--- a/src/README.md
+++ b/src/README.md
@@ -98,23 +98,25 @@ section).
 In order to build the Trove charm, execute the following commands:
 
 ```bash
-export CHARM_BASE="$HOME/work/charms"
-export JUJU_REPOSITORY="$CHARM_BASE/builds"
-
-mkdir -p $JUJU_REPOSITORY
-
 # Install requirement for charm building.
-sudo snap install --classic charm
+sudo snap install charmcraft --classic
 
 # Clone the repository.
 git clone https://github.com/cloudbase/trove-charm
 cd trove-charm
 
 # Build the charm.
-charm build src
+tox -e build
+
+# Alternatively, you can install the charm snap and build the charm:
+sudo snap install charm --classic
+tox -e build-reactive
 ```
 
-The charm should have been built in ``$JUJU_REPOSITORY/builds/trove``.
+The charm should have been built in ``./trove_ubuntu-22.04-amd64.charm``, or in
+``./build/trove`` if the charm was built with the ``charm`` building tools
+instead of ``charmcraft``. This charm path will be used to deploy or refresh
+the Trove charm.
 
 
 ## Deploy the charm
@@ -122,7 +124,7 @@ The charm should have been built in ``$JUJU_REPOSITORY/builds/trove``.
 ```bash
 # The charm can be deployed on a specific node, or an LXD container on a node
 # by specifying the --to argument.
-juju deploy $JUJU_REPOSITORY/builds/trove trove
+juju deploy ./trove_ubuntu-22.04-amd64.charm trove
 
 # Add MySQL Router.
 juju deploy mysql-router trove-mysql-router --channel 8.0/stable
@@ -142,7 +144,7 @@ To replace the current Trove charm with a newer revision and keeping the
 existing relations and configuration, run the following command:
 
 ```bash
-juju refresh --path $JUJU_REPOSITORY/builds/trove-charm trove
+juju refresh --path ./trove_ubuntu-22.04-amd64.charm trove
 ```
 
 In order for the Trove charm to become Active, the ``management-network``

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,16 @@ deps =
 
 [testenv:build]
 basepython = python3
+# charmcraft clean is done to ensure that `tox -e build` always performs
+# a clean, repeatable build. For faster rebuilds during development,
+# directly run `charmcraft -v pack`.
+commands =
+    charmcraft clean
+    charmcraft -v pack
+    charmcraft clean
+
+[testenv:build-reactive]
+basepython = python3
 commands =
     charm-build --log-level DEBUG -o {toxinidir}/build src {posargs}
 


### PR DESCRIPTION
Running ``tox -e build`` will now use ``charmcraft`` to build the charm. The older build method can now be used with ``tox -e build-reactive``.

Updates the README to use the ``charmcraft`` tox target.